### PR TITLE
Refactor/registry factory impl

### DIFF
--- a/src/core/algorithms/Caesar.cpp
+++ b/src/core/algorithms/Caesar.cpp
@@ -1,7 +1,10 @@
 #include "Caesar.hpp"
+#include "../factory/AlgorithmFactory.hpp"
 
 Caesar::Caesar(){}
 Caesar::~Caesar(){}
+
+// bool Caesar::registered = AlgorithmFactory::registerAlgorithm("caesar", [](){ return std::make_unique<Caesar>();});
 
 void Caesar::encrypt(const std::string& inputFileName, const std::string& outputFileName)
 {

--- a/src/core/algorithms/Caesar.hpp
+++ b/src/core/algorithms/Caesar.hpp
@@ -11,4 +11,5 @@ class Caesar : public AlgorithmBase
         void decrypt(const std::string& inputFileName, const std::string& outputFileName) override;
     private :
         int getShiftValue();
+        // static bool registered;
 };

--- a/src/core/factory/AlgorithmFactory.cpp
+++ b/src/core/factory/AlgorithmFactory.cpp
@@ -1,12 +1,21 @@
 #include "AlgorithmFactory.hpp"
 
+// std::unordered_map<std::string, AlgorithmCreator> AlgorithmFactory::registry;
+
 std::unique_ptr<AlgorithmBase> AlgorithmFactory::createAlgorithm(const std::string& algorithmType)
 {
-    if(algorithmType == "caesar") {
-        return std::make_unique<Caesar>();
-    } else if (algorithmType == "xor") {
-        return std::make_unique<XOR>();
+    auto pair = registry.find(algorithmType);
+    if(pair != registry.end()) {
+        return pair->second();
     } else {
-        throw std::invalid_argument("Unknown algorithm: " + algorithmType);
+        throw std::invalid_argument("Unkown algorithm: " + algorithmType);
     }
 }
+void AlgorithmFactory::registerAlgorithm(const std::string& algorithmType,  AlgorithmCreator creator) {
+    registry[algorithmType] = creator;
+}
+
+// bool AlgorithmFactory::registerAlgorithm(const std::string& algorithmType,  AlgorithmCreator creator) { 
+//     return registry.emplace(algorithmType, creator).second;
+// }
+

--- a/src/core/factory/AlgorithmFactory.hpp
+++ b/src/core/factory/AlgorithmFactory.hpp
@@ -1,13 +1,19 @@
 #pragma once
 #include "../algorithm.hpp"
-#include "../algorithms/Caesar.hpp"
-#include "../algorithms/XOR.hpp"
 #include <memory>
+#include <unordered_map>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 
+using AlgorithmCreator = std::function<std::unique_ptr<AlgorithmBase>()>;
+
 class AlgorithmFactory
 {
-    public:
-        static std::unique_ptr<AlgorithmBase> createAlgorithm(const std::string& algorithmType);
+    public :
+        std::unique_ptr<AlgorithmBase> createAlgorithm(const std::string& algorithmType);
+        // static bool registerAlgorithm(const std::string& algorithmType, AlgorithmCreator creator);
+        void registerAlgorithm(const std::string& algorithmType, AlgorithmCreator creator);
+    private : 
+        std::unordered_map<std::string, AlgorithmCreator> registry;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,11 @@
 #include <iostream>
+#include <memory>
 #include "./core/factory/AlgorithmFactory.hpp"
-
+#include "./core/algorithms/Caesar.hpp"
+void initRegistry(AlgorithmFactory& factory) 
+{
+    factory.registerAlgorithm("caesar", [](){ return std::make_unique<Caesar>(); });
+}
 int main(int argc, char* argv[])
 {
     if(argc != 5) {
@@ -14,12 +19,16 @@ int main(int argc, char* argv[])
 
     
     try {
-        auto cipher = AlgorithmFactory::createAlgorithm(algorithm);
-        if(flag == "-e") cipher->encrypt(inputFile,outputFile);
-        else if (flag == "-d") cipher->decrypt(inputFile,outputFile);
-        else {
-            std::cerr << "Unknown flag: " << flag << std::endl;
-            return 1;
+        AlgorithmFactory factory;
+        initRegistry(factory);
+        
+        auto cipher = factory.createAlgorithm(algorithm);
+        if(flag == "-e") {
+            cipher->encrypt(inputFile, outputFile);
+        } else if (flag == "-d") {
+            cipher->decrypt(inputFile, outputFile);
+        } else {
+            throw std::invalid_argument("Unknown flag: " + flag);
         }
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,14 +2,16 @@
 #include <memory>
 #include "./core/factory/AlgorithmFactory.hpp"
 #include "./core/algorithms/Caesar.hpp"
+#include "./core/algorithms/XOR.hpp"
 void initRegistry(AlgorithmFactory& factory) 
 {
     factory.registerAlgorithm("caesar", [](){ return std::make_unique<Caesar>(); });
+    factory.registerAlgorithm("xor", [](){ return std::make_unique<XOR>(); });
 }
 int main(int argc, char* argv[])
 {
     if(argc != 5) {
-        std::cerr << "Usage: ./encrypt_tool <-e/-d> <algorithm> <input file> <output file>" << std::endl;
+        std::cerr << "Usage: ./cypher <-e/-d> <algorithm> <input file> <output file>" << std::endl;
         return 1;
     }
     std::string flag = argv[1];


### PR DESCRIPTION
PR refactors the initial existing factory implementation for algorithm creation to adopt a map-based registry approach, aiming to replace the need for additional if-else statements.

** Registry System **
- Used an unordered_map to dynamically register algorithms using string keys, allowing easy extension by adding a new key-value pair
- Supports clean separation of algorithm registration and instantiation logic

** Factory Design **
- Removed conditional checks for specific algorithms within the AlgorithmFactory class
- Added a registerAlgorithm() to register new algorithms

** Enhanced Extensibility **
- The registry can now support additional algorithms without modifying existing factory code